### PR TITLE
feat: add basic POS product and sale models

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,12 @@ Feel free to check out the [Strapi GitHub repository](https://github.com/strapi/
 ---
 
 <sub>🤫 Psst! [Strapi is hiring](https://strapi.io/careers).</sub>
+
+## 🛒 POS system
+
+This project now includes a basic point of sale (POS) setup to manage clothing store inventory and sales. It exposes `Product` and `Sale` content types:
+
+- **Product**: stores item name, price, and stock count.
+- **Sale**: records product sales, updates stock, and calculates totals.
+
+Run the Strapi server and use the API or admin panel to create products and record sales.

--- a/src/api/product/content-types/product/schema.json
+++ b/src/api/product/content-types/product/schema.json
@@ -1,0 +1,33 @@
+{
+  "kind": "collectionType",
+  "collectionName": "products",
+  "info": {
+    "singularName": "product",
+    "pluralName": "products",
+    "displayName": "Product",
+    "description": "Products available for sale"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "attributes": {
+    "name": {
+      "type": "string",
+      "required": true
+    },
+    "price": {
+      "type": "decimal",
+      "required": true
+    },
+    "stock": {
+      "type": "integer",
+      "required": true
+    },
+    "sales": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::sale.sale",
+      "mappedBy": "product"
+    }
+  }
+}

--- a/src/api/product/controllers/product.js
+++ b/src/api/product/controllers/product.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ *  product controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::product.product');

--- a/src/api/product/routes/product.js
+++ b/src/api/product/routes/product.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * product router.
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::product.product');

--- a/src/api/product/services/product.js
+++ b/src/api/product/services/product.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * product service.
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::product.product');

--- a/src/api/sale/content-types/sale/schema.json
+++ b/src/api/sale/content-types/sale/schema.json
@@ -1,0 +1,31 @@
+{
+  "kind": "collectionType",
+  "collectionName": "sales",
+  "info": {
+    "singularName": "sale",
+    "pluralName": "sales",
+    "displayName": "Sale",
+    "description": "Sales transactions"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "attributes": {
+    "product": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::product.product",
+      "inversedBy": "sales"
+    },
+    "quantity": {
+      "type": "integer",
+      "required": true
+    },
+    "total": {
+      "type": "decimal"
+    },
+    "saleDate": {
+      "type": "datetime"
+    }
+  }
+}

--- a/src/api/sale/controllers/sale.js
+++ b/src/api/sale/controllers/sale.js
@@ -1,0 +1,44 @@
+'use strict';
+
+/**
+ *  sale controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::sale.sale', ({ strapi }) => ({
+  async create(ctx) {
+    const { data } = ctx.request.body;
+    const { product: productId, quantity } = data || {};
+
+    if (!productId || !quantity) {
+      return ctx.badRequest('product and quantity are required');
+    }
+
+    const product = await strapi.entityService.findOne('api::product.product', productId, { fields: ['price', 'stock'] });
+    if (!product) {
+      return ctx.badRequest('Product not found');
+    }
+    if (product.stock < quantity) {
+      return ctx.badRequest('Insufficient stock');
+    }
+
+    const total = Number(product.price) * quantity;
+
+    const sale = await strapi.entityService.create('api::sale.sale', {
+      data: {
+        ...data,
+        total,
+      },
+    });
+
+    await strapi.entityService.update('api::product.product', productId, {
+      data: {
+        stock: product.stock - quantity,
+      },
+    });
+
+    const sanitized = await this.sanitizeOutput(sale, ctx);
+    return this.transformResponse(sanitized);
+  }
+}));

--- a/src/api/sale/routes/sale.js
+++ b/src/api/sale/routes/sale.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * sale router.
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::sale.sale');

--- a/src/api/sale/services/sale.js
+++ b/src/api/sale/services/sale.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * sale service.
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::sale.sale');


### PR DESCRIPTION
## Summary
- add Product content type with price and stock management
- add Sale content type and controller that deducts product stock
- document new POS capabilities

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68b8f901fb748328b6c2e66a52f795de